### PR TITLE
Pin warp-lang version to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "metatrain>=2026.2,<2026.3",
     "metatomic-ase",
     "nvalchemi-toolkit-ops==0.3.0",
+    "warp-lang==0.13.0",
     "huggingface_hub",
     "hf_xet",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "metatrain>=2026.2,<2026.3",
     "metatomic-ase",
     "nvalchemi-toolkit-ops==0.3.0",
-    "warp-lang==0.13.0",
+    "warp-lang==1.13.0",
     "huggingface_hub",
     "hf_xet",
     "packaging",


### PR DESCRIPTION
temporary fix to avoid the `AttributeError: module 'warp._src.utils' has no attribute 'warn'` error