### PR TITLE
Update to metatrain v2026.4 and fix uncertainty under rotational averaging

### DIFF
--- a/docs/src/models.rst
+++ b/docs/src/models.rst
@@ -199,9 +199,6 @@ support ``non_conservative=True``:
 - ``pet-mols-s`` v1.0.0
 - ``pet-mols-s`` v1.1.0
 
-The ``pet-omol`` checkpoints predict non-conservative forces but no
-non-conservative stress, which is computed by backpropagation instead.
-
 PET-MAD-DOS
 -----------
 

--- a/docs/src/models.rst
+++ b/docs/src/models.rst
@@ -39,6 +39,16 @@ The following pre-trained UPET models are available:
      - S, L
      - molecules (17 elements)
      - SPICE
+   * - PET-OMol
+     - ωB97M-V
+     - S, M, L
+     - molecules (83 elements)
+     - OMol25
+   * - PET-MOLS
+     - PBE0+MBD
+     - S
+     - organic molecular crystals (12 elements)
+     - CSD subsample
 
 Recommended usage:
 
@@ -49,6 +59,10 @@ Recommended usage:
   geometry optimization, phonons, etc.).
 - **PET-SPICE** for accurate and fast simulations of molecules and
   biomolecules.
+- **PET-OMol** for simulations of molecules, metal complexes and
+  electrolytes.
+- **PET-MOLS** for organic molecular crystals, in particular NMR
+  crystallography.
 
 Model sizes
 -----------
@@ -157,7 +171,7 @@ details on the models being compared).
 Uncertainty quantification
 --------------------------
 
-A subset of PET-MAD checkpoints expose per-structure energy uncertainty
+A subset of the checkpoints expose per-structure energy uncertainty
 estimates through :py:meth:`~upet.calculator.UPETCalculator.get_energy_uncertainty`
 and :py:meth:`~upet.calculator.UPETCalculator.get_energy_ensemble`
 (LLPR + shallow-ensemble heads, see :ref:`ase-uncertainty` for usage):
@@ -165,6 +179,8 @@ and :py:meth:`~upet.calculator.UPETCalculator.get_energy_ensemble`
 - ``pet-mad-s`` v1.0.2
 - ``pet-mad-xs`` v1.5.0
 - ``pet-mad-s`` v1.5.0
+- ``pet-mols-s`` v1.0.0
+- ``pet-mols-s`` v1.1.0
 
 Calling these methods on other checkpoints will raise an error.
 
@@ -180,6 +196,11 @@ support ``non_conservative=True``:
 - ``pet-mad-s`` v1.0.2
 - ``pet-spice-s`` v0.2.0
 - ``pet-spice-l`` v0.2.0
+- ``pet-mols-s`` v1.0.0
+- ``pet-mols-s`` v1.1.0
+
+The ``pet-omol`` checkpoints predict non-conservative forces but no
+non-conservative stress, which is computed by backpropagation instead.
 
 PET-MAD-DOS
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ maintainers = [
 ]
 
 dependencies = [
-    "metatrain>=2026.3.1, <2026.4",
-    "metatomic-ase",
+    "metatrain>=2026.4, <2026.5",
+    "metatomic-ase>=0.1.3, <0.2",
     "nvalchemi-toolkit-ops",
     "warp-lang",
     "huggingface_hub",

--- a/src/upet/_metadata.py
+++ b/src/upet/_metadata.py
@@ -28,6 +28,29 @@ OMOL_REFERENCES = {
 }
 
 
+# PET-MOLS is not a universal potential, so it does not use the generic
+# description below.
+MOLS_DESCRIPTION = (
+    r"A machine-learning interatomic potential to study organic molecular "
+    r"crystals, trained on periodic PBE0+MBD reference data, covering 12 "
+    r"elements and a broad range of organic motifs subsampled from the "
+    r"Cambridge Structural Database. Model size: {}. Model version: {}."
+)
+
+# Same order as the model paper (arXiv:2603.06236).
+MOLS_AUTHORS = [
+    "Matthias Kellner (matthias.kellner@epfl.ch)",
+    "Ruben Rodriguez-Madrid",
+    "Jacob B. Holmes",
+    "Victor Paul Principe",
+    "Seio Inoue",
+    "Lyndon Emsley",
+    "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+]
+
+MOLS_REFERENCES = {"model": ["https://arxiv.org/abs/2603.06236"]}
+
+
 def get_upet_metadata(
     model: Optional[str] = None,
     size: Optional[str] = None,
@@ -48,7 +71,12 @@ def get_upet_metadata(
 
     if model and size and version:
         dataset = DATASET_NAMES.get(model, model.split("-")[1].upper())
-        if "omol" in model.lower():
+        description_text = description.format(dataset, size, version)
+        if "mols" in model.lower():
+            authors = MOLS_AUTHORS
+            references = MOLS_REFERENCES
+            description_text = MOLS_DESCRIPTION.format(size, version)
+        elif "omol" in model.lower():
             authors = OMOL_AUTHORS
             references = OMOL_REFERENCES
         elif "mad" in model.lower():
@@ -72,7 +100,7 @@ def get_upet_metadata(
             ]
         metadata = ModelMetadata(
             name=f"{model.upper()}-{size.upper()} v{version}",
-            description=description.format(dataset, size, version),
+            description=description_text,
             authors=authors,
             references=references,
         )

--- a/src/upet/_metadata.py
+++ b/src/upet/_metadata.py
@@ -3,54 +3,6 @@ from typing import Optional
 from metatomic.torch import ModelMetadata
 
 
-# Official spelling of the training dataset, when it differs from the one that
-# can be derived from the model name.
-DATASET_NAMES = {"pet-omol": "OMol25"}
-
-# Same order as the model paper (doi:10.1088/2632-2153/ae6417).
-OMOL_AUTHORS = [
-    "Filippo Bigi (filippo.bigi@epfl.ch)",
-    "Paolo Pegolo (paolo.pegolo@epfl.ch)",
-    "Arslan Mazitov (arslan.mazitov@epfl.ch)",
-    "Jonathan Schmidt",
-    "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-]
-
-# ``dataset`` is not an accepted key of ModelMetadata.references, so the OMol25
-# dataset paper is listed together with the model one.
-OMOL_REFERENCES = {
-    # the original PET preprint is added by PET's own default metadata
-    "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
-    "model": [
-        "https://doi.org/10.1088/2632-2153/ae6417",
-        "https://arxiv.org/abs/2505.08762",
-    ],
-}
-
-
-# PET-MOLS is not a universal potential, so it does not use the generic
-# description below.
-MOLS_DESCRIPTION = (
-    r"A machine-learning interatomic potential to study organic molecular "
-    r"crystals, trained on periodic PBE0+MBD reference data, covering 12 "
-    r"elements and a broad range of organic motifs subsampled from the "
-    r"Cambridge Structural Database. Model size: {}. Model version: {}."
-)
-
-# Same order as the model paper (arXiv:2603.06236).
-MOLS_AUTHORS = [
-    "Matthias Kellner (matthias.kellner@epfl.ch)",
-    "Ruben Rodriguez-Madrid",
-    "Jacob B. Holmes",
-    "Victor Paul Principe",
-    "Seio Inoue",
-    "Lyndon Emsley",
-    "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-]
-
-MOLS_REFERENCES = {"model": ["https://arxiv.org/abs/2603.06236"]}
-
-
 def get_upet_metadata(
     model: Optional[str] = None,
     size: Optional[str] = None,
@@ -70,15 +22,48 @@ def get_upet_metadata(
     }
 
     if model and size and version:
-        dataset = DATASET_NAMES.get(model, model.split("-")[1].upper())
+        dataset = model.split("-")[1].upper()
         description_text = description.format(dataset, size, version)
         if "mols" in model.lower():
-            authors = MOLS_AUTHORS
-            references = MOLS_REFERENCES
-            description_text = MOLS_DESCRIPTION.format(size, version)
+            # PET-MOLS is not a universal potential, so it does not use the
+            # generic description above
+            description_text = (
+                r"A machine-learning interatomic potential to study organic "
+                r"molecular crystals, trained on periodic PBE0+MBD reference "
+                r"data, covering 12 elements and a broad range of organic "
+                r"motifs subsampled from the Cambridge Structural Database. "
+                r"Model size: {}. Model version: {}.".format(size, version)
+            )
+            # same order as the model paper (arXiv:2603.06236)
+            authors = [
+                "Matthias Kellner (matthias.kellner@epfl.ch)",
+                "Ruben Rodriguez-Madrid",
+                "Jacob B. Holmes",
+                "Victor Paul Principe",
+                "Seio Inoue",
+                "Lyndon Emsley",
+                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+            ]
+            references = {"model": ["https://arxiv.org/abs/2603.06236"]}
         elif "omol" in model.lower():
-            authors = OMOL_AUTHORS
-            references = OMOL_REFERENCES
+            description_text = description.format("OMol25", size, version)
+            # same order as the model paper (doi:10.1088/2632-2153/ae6417)
+            authors = [
+                "Filippo Bigi (filippo.bigi@epfl.ch)",
+                "Paolo Pegolo (paolo.pegolo@epfl.ch)",
+                "Arslan Mazitov (arslan.mazitov@epfl.ch)",
+                "Jonathan Schmidt",
+                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+            ]
+            references = {
+                "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
+                # ``dataset`` is not an accepted key of the references, so the
+                # OMol25 dataset paper is listed together with the model one
+                "model": [
+                    "https://doi.org/10.1088/2632-2153/ae6417",
+                    "https://arxiv.org/abs/2505.08762",
+                ],
+            }
         elif "mad" in model.lower():
             authors = [
                 "Arslan Mazitov (arslan.mazitov@epfl.ch)",

--- a/src/upet/_metadata.py
+++ b/src/upet/_metadata.py
@@ -3,6 +3,31 @@ from typing import Optional
 from metatomic.torch import ModelMetadata
 
 
+# Official spelling of the training dataset, when it differs from the one that
+# can be derived from the model name.
+DATASET_NAMES = {"pet-omol": "OMol25"}
+
+# Same order as the model paper (doi:10.1088/2632-2153/ae6417).
+OMOL_AUTHORS = [
+    "Filippo Bigi (filippo.bigi@epfl.ch)",
+    "Paolo Pegolo (paolo.pegolo@epfl.ch)",
+    "Arslan Mazitov (arslan.mazitov@epfl.ch)",
+    "Jonathan Schmidt",
+    "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+]
+
+# ``dataset`` is not an accepted key of ModelMetadata.references, so the OMol25
+# dataset paper is listed together with the model one.
+OMOL_REFERENCES = {
+    # the original PET preprint is added by PET's own default metadata
+    "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
+    "model": [
+        "https://doi.org/10.1088/2632-2153/ae6417",
+        "https://arxiv.org/abs/2505.08762",
+    ],
+}
+
+
 def get_upet_metadata(
     model: Optional[str] = None,
     size: Optional[str] = None,
@@ -22,8 +47,11 @@ def get_upet_metadata(
     }
 
     if model and size and version:
-        dataset = model.split("-")[1].upper()
-        if "mad" in model.lower():
+        dataset = DATASET_NAMES.get(model, model.split("-")[1].upper())
+        if "omol" in model.lower():
+            authors = OMOL_AUTHORS
+            references = OMOL_REFERENCES
+        elif "mad" in model.lower():
             authors = [
                 "Arslan Mazitov (arslan.mazitov@epfl.ch)",
                 "Filippo Bigi",

--- a/src/upet/_version.py
+++ b/src/upet/_version.py
@@ -28,15 +28,6 @@ UPET_NO_NC_SUPPORT_MODELS = [
     "pet-mols-s-v1.1.0",
 ]
 
-# Models predicting non-conservative forces but no non-conservative stress, since
-# they were trained on non-periodic data. Their stress is computed by
-# backpropagation even when the non-conservative regime is requested.
-UPET_NO_NC_STRESS_MODELS = [
-    "pet-omol-s-v1.0.0",
-    "pet-omol-m-v1.0.0",
-    "pet-omol-l-v1.0.0",
-]
-
 UPET_UQ_SUPPORTED_MODELS = [
     "pet-mad-s-v1.0.2",
     "pet-mad-xs-v1.5.0",

--- a/src/upet/_version.py
+++ b/src/upet/_version.py
@@ -12,6 +12,9 @@ UPET_AVAILABLE_MODELS = [
     "pet-omad-s",
     "pet-omad-l",
     "pet-omatpes-l",
+    "pet-omol-s",
+    "pet-omol-m",
+    "pet-omol-l",
     "pet-spice-s",
     "pet-spice-l",
 ]

--- a/src/upet/_version.py
+++ b/src/upet/_version.py
@@ -24,6 +24,17 @@ UPET_NO_NC_SUPPORT_MODELS = [
     "pet-mad-s-v1.0.2",
     "pet-spice-s-v0.2.0",
     "pet-spice-l-v0.2.0",
+    "pet-mols-s-v1.0.0",
+    "pet-mols-s-v1.1.0",
+]
+
+# Models predicting non-conservative forces but no non-conservative stress, since
+# they were trained on non-periodic data. Their stress is computed by
+# backpropagation even when the non-conservative regime is requested.
+UPET_NO_NC_STRESS_MODELS = [
+    "pet-omol-s-v1.0.0",
+    "pet-omol-m-v1.0.0",
+    "pet-omol-l-v1.0.0",
 ]
 
 UPET_UQ_SUPPORTED_MODELS = [

--- a/src/upet/_version.py
+++ b/src/upet/_version.py
@@ -15,6 +15,7 @@ UPET_AVAILABLE_MODELS = [
     "pet-omol-s",
     "pet-omol-m",
     "pet-omol-l",
+    "pet-mols-s",
     "pet-spice-s",
     "pet-spice-l",
 ]
@@ -29,6 +30,8 @@ UPET_UQ_SUPPORTED_MODELS = [
     "pet-mad-s-v1.0.2",
     "pet-mad-xs-v1.5.0",
     "pet-mad-s-v1.5.0",
+    "pet-mols-s-v1.0.0",
+    "pet-mols-s-v1.1.0",
 ]
 
 DEPRECATED_MODELS: list[str] = []

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -221,13 +221,25 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         self.calculator.calculate(atoms, properties, system_changes)
         self.results = self.calculator.results
 
+    @property
+    def _base_calculator(self) -> MetatomicCalculator:
+        """The underlying calculator, unwrapped from rotational averaging.
+
+        Uncertainty outputs are not rotationally averaged: they are requested
+        from the base model directly.
+        """
+        calc = self.calculator
+        if isinstance(calc, SymmetrizedCalculator):
+            return calc.base_calculator
+        return calc
+
     def _run_uq(
         self,
         atoms: Optional[Atoms] = None,
         per_atom: bool = False,
         key: str = "energy_uncertainty",
     ) -> np.ndarray:
-        if not self.calculator._calculate_uncertainty:
+        if not self._base_calculator._calculate_uncertainty:
             raise NotImplementedError(
                 "Energy uncertainty and ensemble are not available for the selected "
                 "model. For uncertainty estimates, please use one of the following "
@@ -242,7 +254,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             else:
                 atoms = self.atoms
 
-        outputs = self.calculator.run_model(
+        outputs = self._base_calculator.run_model(
             atoms,
             outputs={
                 key: ModelOutput(
@@ -264,7 +276,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         :param per_atom: Whether to return the energy uncertainty per atom.
         :return: Energy uncertainty in numpy.ndarray format.
         """
-        key = self.calculator._energy_uq_key
+        key = self._base_calculator._energy_uq_key
         return self._run_uq(atoms=atoms, per_atom=per_atom, key=key)
 
     def get_energy_ensemble(
@@ -278,7 +290,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         :param per_atom: Whether to return the energies per atom.
         :return: Energy uncertainty in numpy.ndarray format.
         """
-        key = self.calculator._energy_uq_key.replace("_uncertainty", "_ensemble")
+        key = self._base_calculator._energy_uq_key.replace("_uncertainty", "_ensemble")
         return self._run_uq(atoms=atoms, per_atom=per_atom, key=key)
 
 

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -116,6 +116,11 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
 
             - PET-MAD models with version < 1.1.0
             - PET-SPICE models
+            - PET-MOLS models
+
+            Models trained on non-periodic data only predict non-conservative
+            forces, and their stress is computed by backpropagation regardless of
+            this setting.
         :param check_consistency: whether internal consistency checks should be
             performed. Mainly for developers, defaults to False.
         """
@@ -155,17 +160,23 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             )
 
         model_outputs = loaded_model.capabilities().outputs
+        nc_regime: Union[bool, Literal["forces", "stress"]] = non_conservative
         if non_conservative:
             selected_variant = None if variants is None else variants.get("energy")
             variant_postfix = f"/{selected_variant}" if selected_variant else ""
             nc_forces_key = "non_conservative_force" + variant_postfix
             nc_stress_key = "non_conservative_stress" + variant_postfix
-            if nc_forces_key not in model_outputs or nc_stress_key not in model_outputs:
+            if nc_forces_key not in model_outputs:
                 raise NotImplementedError(
                     "Non-conservative forces and stresses are not available for the "
                     f"model {model}, v{version}. Please run without "
                     "non_conservative=True, or choose another model."
                 )
+            if nc_stress_key not in model_outputs:
+                # models trained on non-periodic data have no non-conservative
+                # stress: the forces still come directly from the model, and the
+                # stress is left to be computed by backpropagation
+                nc_regime = "forces"
 
         if dtype is not None:
             if isinstance(dtype, str):
@@ -180,7 +191,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             check_consistency=check_consistency,
             device=device,
             variants=variants,
-            non_conservative=non_conservative,
+            non_conservative=nc_regime,
         )
         self.implemented_properties = self.calculator.implemented_properties
 

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -123,8 +123,6 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             - PET-SPICE models
             - PET-MOLS models
 
-            PET-OMol models only predict non-conservative forces, so their stress
-            is computed by backpropagation even when this is set.
         :param check_consistency: whether internal consistency checks should be
             performed. Mainly for developers, defaults to False.
         """

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -174,15 +174,22 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             nc_forces_key = "non_conservative_force" + variant_postfix
             nc_stress_key = "non_conservative_stress" + variant_postfix
 
-            if (
-                non_conservative == "forces" and nc_forces_key not in model_outputs
-            ) or (non_conservative == "stress" and nc_stress_key not in model_outputs):
+            missing_nc_forces = (
+                non_conservative in ("forces", True)
+                and nc_forces_key not in model_outputs
+            )
+            missing_nc_stress = (
+                non_conservative in ("stress", True)
+                and nc_stress_key not in model_outputs
+            )
+
+            if missing_nc_forces or missing_nc_stress:
                 raise NotImplementedError(
-                    f"Non-conservative {non_conservative} are not available for the "
-                    f"model {model}, v{version}, and a target variant "
-                    f"{selected_variant or 'energy'}. Please choose another "
-                    "non-conservative option or target vairant, switch to a "
-                    "conservative regime or choose another model."
+                    f"`non-conservative={non_conservative}` option is not available "
+                    f"for the model {model}, v{version}, and a target variant "
+                    f"`{selected_variant or 'energy'}`. Please choose another "
+                    f"`non-conservative` option, use another target variant, "
+                    "switch to a conservative regime or choose another model."
                 )
 
         if dtype is not None:

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -244,7 +244,11 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
 
         outputs = self.calculator.run_model(
             atoms,
-            outputs={key: ModelOutput(quantity="energy", unit="eV", per_atom=per_atom)},
+            outputs={
+                key: ModelOutput(
+                    unit="eV", sample_kind="atom" if per_atom else "system"
+                )
+            },
         )
 
         return outputs[key].block().values.detach().cpu().numpy()
@@ -412,7 +416,10 @@ class PETMADDOSCalculator(ase.calculators.calculator.Calculator):
         :return: Energy grid and corresponding DOS values in torch.Tensor format.
         """
         results = self.calculator.run_model(
-            atoms, outputs={"mtt::dos": ModelOutput(per_atom=per_atom)}
+            atoms,
+            outputs={
+                "mtt::dos": ModelOutput(sample_kind="atom" if per_atom else "system")
+            },
         )
         dos = results["mtt::dos"].block().values
 

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -78,6 +78,11 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             - "pet-omatpes-l": PET-OMATPES model (size "l", materials, r2SCAN)
             - "pet-spice-s": PET-SPICE model (size "s", molecules, ωB97M-D3)
             - "pet-spice-l": PET-SPICE model (size "l", molecules, ωB97M-D3)
+            - "pet-omol-s": PET-OMol model (size "s", molecules, ωB97M-V)
+            - "pet-omol-m": PET-OMol model (size "m", molecules, ωB97M-V)
+            - "pet-omol-l": PET-OMol model (size "l", molecules, ωB97M-V)
+            - "pet-mols-s": PET-MOLS model (size "s", organic molecular crystals,
+              PBE0+MBD)
         :param version: version of the model to use. Defaults to the latest stable
             version. Deprecated model versions:
 
@@ -118,9 +123,8 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             - PET-SPICE models
             - PET-MOLS models
 
-            Models trained on non-periodic data only predict non-conservative
-            forces, and their stress is computed by backpropagation regardless of
-            this setting.
+            PET-OMol models only predict non-conservative forces, so their stress
+            is computed by backpropagation even when this is set.
         :param check_consistency: whether internal consistency checks should be
             performed. Mainly for developers, defaults to False.
         """
@@ -168,14 +172,12 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             nc_stress_key = "non_conservative_stress" + variant_postfix
             if nc_forces_key not in model_outputs:
                 raise NotImplementedError(
-                    "Non-conservative forces and stresses are not available for the "
+                    "Non-conservative forces are not available for the "
                     f"model {model}, v{version}. Please run without "
                     "non_conservative=True, or choose another model."
                 )
             if nc_stress_key not in model_outputs:
-                # models trained on non-periodic data have no non-conservative
-                # stress: the forces still come directly from the model, and the
-                # stress is left to be computed by backpropagation
+                # the stress is left to backpropagation
                 nc_regime = "forces"
 
         if dtype is not None:
@@ -234,11 +236,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
 
     @property
     def _base_calculator(self) -> MetatomicCalculator:
-        """The underlying calculator, unwrapped from rotational averaging.
-
-        Uncertainty outputs are not rotationally averaged: they are requested
-        from the base model directly.
-        """
+        """The underlying calculator, unwrapped from rotational averaging."""
         calc = self.calculator
         if isinstance(calc, SymmetrizedCalculator):
             return calc.base_calculator
@@ -286,6 +284,9 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             used.
         :param per_atom: Whether to return the energy uncertainty per atom.
         :return: Energy uncertainty in numpy.ndarray format.
+
+        The uncertainty is not rotationally averaged, even when the calculator
+        is: it is requested from the base model directly.
         """
         key = self._base_calculator._energy_uq_key
         return self._run_uq(atoms=atoms, per_atom=per_atom, key=key)
@@ -300,6 +301,9 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             used.
         :param per_atom: Whether to return the energies per atom.
         :return: Energy uncertainty in numpy.ndarray format.
+
+        The ensemble is not rotationally averaged, even when the calculator is:
+        it is requested from the base model directly.
         """
         key = self._base_calculator._energy_uq_key.replace("_uncertainty", "_ensemble")
         return self._run_uq(atoms=atoms, per_atom=per_atom, key=key)

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -56,7 +56,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         rotational_average_batch_size: Optional[int] = None,
         *,
         device: Optional[str] = None,
-        non_conservative: bool = False,
+        non_conservative: Union[bool, Literal["forces", "stress"]] = False,
         check_consistency: bool = False,
     ):
         """
@@ -116,8 +116,14 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         :param device: torch device to use for the calculation. If `None`, we will try
             the options in the model's `supported_device` in order.
         :param non_conservative: whether to use the non-conservative regime of forces
-            and stresses prediction. Defaults to False. Available for all models,
-            except:
+            and / or stresses prediction. Available options are:
+
+            - False: use the conservative regime (default)
+            - True: use the non-conservative regime for both forces and stresses
+            - "forces": use the non-conservative regime for forces only
+            - "stress": use the non-conservative regime for stresses only
+
+            Defaults to False. Available for all models, except:
 
             - PET-MAD models with version < 1.1.0
             - PET-SPICE models
@@ -161,22 +167,23 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
                 checkpoint_path=checkpoint_path,
             )
 
-        model_outputs = loaded_model.capabilities().outputs
-        nc_regime: Union[bool, Literal["forces", "stress"]] = non_conservative
         if non_conservative:
+            model_outputs = loaded_model.capabilities().outputs
             selected_variant = None if variants is None else variants.get("energy")
             variant_postfix = f"/{selected_variant}" if selected_variant else ""
             nc_forces_key = "non_conservative_force" + variant_postfix
             nc_stress_key = "non_conservative_stress" + variant_postfix
-            if nc_forces_key not in model_outputs:
+
+            if (
+                non_conservative == "forces" and nc_forces_key not in model_outputs
+            ) or (non_conservative == "stress" and nc_stress_key not in model_outputs):
                 raise NotImplementedError(
-                    "Non-conservative forces are not available for the "
-                    f"model {model}, v{version}. Please run without "
-                    "non_conservative=True, or choose another model."
+                    f"Non-conservative {non_conservative} are not available for the "
+                    f"model {model}, v{version}, and a target variant "
+                    f"{selected_variant or 'energy'}. Please choose another "
+                    "non-conservative option or target vairant, switch to a "
+                    "conservative regime or choose another model."
                 )
-            if nc_stress_key not in model_outputs:
-                # the stress is left to backpropagation
-                nc_regime = "forces"
 
         if dtype is not None:
             if isinstance(dtype, str):
@@ -191,7 +198,7 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             check_consistency=check_consistency,
             device=device,
             variants=variants,
-            non_conservative=nc_regime,
+            non_conservative=non_conservative,
         )
         self.implemented_properties = self.calculator.implemented_properties
 

--- a/tests/upet/test_basic_usage.py
+++ b/tests/upet/test_basic_usage.py
@@ -84,9 +84,10 @@ def test_basic_usage(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
-        bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
-        if "spice" not in model_name
-        else molecule("H2O")
+        molecule("H2O")
+        # models trained on molecular data only
+        if any(name in model_name for name in ("spice", "mols"))
+        else bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
     )
 
     model, size = model_name.rsplit("-", 1)

--- a/tests/upet/test_basic_usage.py
+++ b/tests/upet/test_basic_usage.py
@@ -85,7 +85,6 @@ def test_basic_usage(model_name):
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
         molecule("H2O")
-        # models trained on molecular data only
         if any(name in model_name for name in ("spice", "mols"))
         else bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
     )

--- a/tests/upet/test_md.py
+++ b/tests/upet/test_md.py
@@ -18,7 +18,6 @@ def test_md(model_name):
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
         molecule("H2O")
-        # models trained on molecular data only
         if any(name in model_name for name in ("spice", "mols"))
         else bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
     )

--- a/tests/upet/test_md.py
+++ b/tests/upet/test_md.py
@@ -17,9 +17,10 @@ def test_md(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
-        bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
-        if "spice" not in model_name
-        else molecule("H2O")
+        molecule("H2O")
+        # models trained on molecular data only
+        if any(name in model_name for name in ("spice", "mols"))
+        else bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
     )
 
     model, size = model_name.rsplit("-", 1)

--- a/tests/upet/test_metadata.py
+++ b/tests/upet/test_metadata.py
@@ -1,92 +1,95 @@
-import pytest
-
 from upet._metadata import get_upet_metadata
-from upet._models import get_versions_for_model
-from upet._version import UPET_AVAILABLE_MODELS
 
 
-@pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)
-def test_get_upet_metadata(model_name):
-    if "-xl" in model_name or "-l" in model_name:
-        pytest.skip("Skipping XL models and L models due to large size.")
-    model, size = model_name.rsplit("-", 1)
-    all_model_versions = get_versions_for_model(model, size)
+PET_REFERENCES = {
+    "architecture": ["https://arxiv.org/abs/2305.19302v3"],
+    "model": [
+        "https://doi.org/10.1038/s41467-025-65662-7",
+        "https://arxiv.org/abs/2601.16195",
+    ],
+}
 
-    for version in all_model_versions:
-        model, size = model_name.rsplit("-", 1)
-        metadata = get_upet_metadata(model, size, version)
 
-        description = (
-            r"A universal interatomic potential for advanced materials modeling "
-            r"based on a Point-Edge Transformer (PET) architecture, and trained on "
-            r"the {} dataset. Model size: {}. Model version: {}.".format(
-                model.split("-")[1].upper(), size, version
-            )
-        )
-        references = {
-            "architecture": ["https://arxiv.org/abs/2305.19302v3"],
-            "model": [
-                "https://doi.org/10.1038/s41467-025-65662-7",
-                "https://arxiv.org/abs/2601.16195",
-            ],
-        }
+def test_metadata_default():
+    metadata = get_upet_metadata("pet-omat", "s", "1.0.0")
 
-        if "mad" in model.lower():
-            authors = [
-                "Arslan Mazitov (arslan.mazitov@epfl.ch)",
-                "Filippo Bigi",
-                "Matthias Kellner",
-                "Paolo Pegolo",
-                "Davide Tisi",
-                "Guillaume Fraux",
-                "Sergey Pozdnyakov",
-                "Philip Loche",
-                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-            ]
-        elif "mols" in model.lower():
-            # PET-MOLS is not a universal potential, and has its own paper
-            description = (
-                r"A machine-learning interatomic potential to study organic "
-                r"molecular crystals, trained on periodic PBE0+MBD reference data, "
-                r"covering 12 elements and a broad range of organic motifs "
-                r"subsampled from the Cambridge Structural Database. "
-                r"Model size: {}. Model version: {}.".format(size, version)
-            )
-            authors = [
-                "Matthias Kellner (matthias.kellner@epfl.ch)",
-                "Ruben Rodriguez-Madrid",
-                "Jacob B. Holmes",
-                "Victor Paul Principe",
-                "Seio Inoue",
-                "Lyndon Emsley",
-                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-            ]
-            references = {"model": ["https://arxiv.org/abs/2603.06236"]}
-        elif "omol" in model.lower():
-            description = description.replace("the OMOL dataset", "the OMol25 dataset")
-            authors = [
-                "Filippo Bigi (filippo.bigi@epfl.ch)",
-                "Paolo Pegolo (paolo.pegolo@epfl.ch)",
-                "Arslan Mazitov (arslan.mazitov@epfl.ch)",
-                "Jonathan Schmidt",
-                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-            ]
-            references = {
-                "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
-                "model": [
-                    "https://doi.org/10.1088/2632-2153/ae6417",
-                    "https://arxiv.org/abs/2505.08762",
-                ],
-            }
-        else:
-            authors = [
-                "Filippo Bigi (filippo.bigi@epfl.ch)",
-                "Arslan Mazitov (arslan.mazitov@epfl.ch)",
-                "Paolo Pegolo",
-                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-            ]
+    assert metadata.name == "PET-OMAT-S v1.0.0"
+    assert metadata.description == (
+        "A universal interatomic potential for advanced materials modeling based "
+        "on a Point-Edge Transformer (PET) architecture, and trained on the OMAT "
+        "dataset. Model size: s. Model version: 1.0.0."
+    )
+    assert metadata.authors == [
+        "Filippo Bigi (filippo.bigi@epfl.ch)",
+        "Arslan Mazitov (arslan.mazitov@epfl.ch)",
+        "Paolo Pegolo",
+        "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+    ]
+    assert metadata.references == PET_REFERENCES
 
-        assert metadata.name == f"{model.upper()}-{size.upper()} v{version}"
-        assert metadata.description == description
-        assert metadata.authors == authors
-        assert metadata.references == references
+
+def test_metadata_mad():
+    metadata = get_upet_metadata("pet-mad", "xs", "1.5.0")
+
+    assert metadata.name == "PET-MAD-XS v1.5.0"
+    assert metadata.authors == [
+        "Arslan Mazitov (arslan.mazitov@epfl.ch)",
+        "Filippo Bigi",
+        "Matthias Kellner",
+        "Paolo Pegolo",
+        "Davide Tisi",
+        "Guillaume Fraux",
+        "Sergey Pozdnyakov",
+        "Philip Loche",
+        "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+    ]
+    assert metadata.references == PET_REFERENCES
+
+
+def test_metadata_omol():
+    """Check the dataset name, which is not the one derived from the model name."""
+    metadata = get_upet_metadata("pet-omol", "s", "1.0.0")
+
+    assert metadata.name == "PET-OMOL-S v1.0.0"
+    assert metadata.description == (
+        "A universal interatomic potential for advanced materials modeling based "
+        "on a Point-Edge Transformer (PET) architecture, and trained on the "
+        "OMol25 dataset. Model size: s. Model version: 1.0.0."
+    )
+    assert metadata.authors == [
+        "Filippo Bigi (filippo.bigi@epfl.ch)",
+        "Paolo Pegolo (paolo.pegolo@epfl.ch)",
+        "Arslan Mazitov (arslan.mazitov@epfl.ch)",
+        "Jonathan Schmidt",
+        "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+    ]
+    assert metadata.references == {
+        "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
+        "model": [
+            "https://doi.org/10.1088/2632-2153/ae6417",
+            "https://arxiv.org/abs/2505.08762",
+        ],
+    }
+
+
+def test_metadata_mols():
+    """Check the description of the only model that is not a universal potential."""
+    metadata = get_upet_metadata("pet-mols", "s", "1.1.0")
+
+    assert metadata.name == "PET-MOLS-S v1.1.0"
+    assert metadata.description == (
+        "A machine-learning interatomic potential to study organic molecular "
+        "crystals, trained on periodic PBE0+MBD reference data, covering 12 "
+        "elements and a broad range of organic motifs subsampled from the "
+        "Cambridge Structural Database. Model size: s. Model version: 1.1.0."
+    )
+    assert metadata.authors == [
+        "Matthias Kellner (matthias.kellner@epfl.ch)",
+        "Ruben Rodriguez-Madrid",
+        "Jacob B. Holmes",
+        "Victor Paul Principe",
+        "Seio Inoue",
+        "Lyndon Emsley",
+        "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+    ]
+    assert metadata.references == {"model": ["https://arxiv.org/abs/2603.06236"]}

--- a/tests/upet/test_metadata.py
+++ b/tests/upet/test_metadata.py
@@ -16,6 +16,21 @@ def test_get_upet_metadata(model_name):
         model, size = model_name.rsplit("-", 1)
         metadata = get_upet_metadata(model, size, version)
 
+        description = (
+            r"A universal interatomic potential for advanced materials modeling "
+            r"based on a Point-Edge Transformer (PET) architecture, and trained on "
+            r"the {} dataset. Model size: {}. Model version: {}.".format(
+                model.split("-")[1].upper(), size, version
+            )
+        )
+        references = {
+            "architecture": ["https://arxiv.org/abs/2305.19302v3"],
+            "model": [
+                "https://doi.org/10.1038/s41467-025-65662-7",
+                "https://arxiv.org/abs/2601.16195",
+            ],
+        }
+
         if "mad" in model.lower():
             authors = [
                 "Arslan Mazitov (arslan.mazitov@epfl.ch)",
@@ -28,6 +43,41 @@ def test_get_upet_metadata(model_name):
                 "Philip Loche",
                 "Michele Ceriotti (michele.ceriotti@epfl.ch)",
             ]
+        elif "mols" in model.lower():
+            # PET-MOLS is not a universal potential, and has its own paper
+            description = (
+                r"A machine-learning interatomic potential to study organic "
+                r"molecular crystals, trained on periodic PBE0+MBD reference data, "
+                r"covering 12 elements and a broad range of organic motifs "
+                r"subsampled from the Cambridge Structural Database. "
+                r"Model size: {}. Model version: {}.".format(size, version)
+            )
+            authors = [
+                "Matthias Kellner (matthias.kellner@epfl.ch)",
+                "Ruben Rodriguez-Madrid",
+                "Jacob B. Holmes",
+                "Victor Paul Principe",
+                "Seio Inoue",
+                "Lyndon Emsley",
+                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+            ]
+            references = {"model": ["https://arxiv.org/abs/2603.06236"]}
+        elif "omol" in model.lower():
+            description = description.replace("the OMOL dataset", "the OMol25 dataset")
+            authors = [
+                "Filippo Bigi (filippo.bigi@epfl.ch)",
+                "Paolo Pegolo (paolo.pegolo@epfl.ch)",
+                "Arslan Mazitov (arslan.mazitov@epfl.ch)",
+                "Jonathan Schmidt",
+                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
+            ]
+            references = {
+                "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
+                "model": [
+                    "https://doi.org/10.1088/2632-2153/ae6417",
+                    "https://arxiv.org/abs/2505.08762",
+                ],
+            }
         else:
             authors = [
                 "Filippo Bigi (filippo.bigi@epfl.ch)",
@@ -37,19 +87,6 @@ def test_get_upet_metadata(model_name):
             ]
 
         assert metadata.name == f"{model.upper()}-{size.upper()} v{version}"
-        assert metadata.description == (
-            r"A universal interatomic potential for advanced materials modeling "
-            r"based on a Point-Edge Transformer (PET) architecture, and trained on "
-            r"the {} dataset. Model size: {}. Model version: {}.".format(
-                model.split("-")[1].upper(), size, version
-            )
-        )
-
+        assert metadata.description == description
         assert metadata.authors == authors
-        assert metadata.references == {
-            "architecture": ["https://arxiv.org/abs/2305.19302v3"],
-            "model": [
-                "https://doi.org/10.1038/s41467-025-65662-7",
-                "https://arxiv.org/abs/2601.16195",
-            ],
-        }
+        assert metadata.references == references

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -10,6 +10,8 @@ from upet.calculator import UPETCalculator
 
 @pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)
 def test_non_conservative(model_name):
+    non_conservative = True
+
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
@@ -24,17 +26,19 @@ def test_non_conservative(model_name):
     for version in all_model_versions:
         if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
             message = (
-                f"Non-conservative forces are not available for the model "
-                f"{model_name}, v{version}. Please run without "
-                "non_conservative=True, or choose another model."
+                f"`non-conservative={non_conservative}` option is not available "
+                f"for the model {model_name}, v{version}, and a target variant "
+                f"`energy`. Please choose another `non-conservative` option, "
+                "use another target variant, switch to a conservative regime "
+                "or choose another model."
             )
             with pytest.raises(NotImplementedError, match=re.escape(message)):
                 calc = UPETCalculator(
-                    model=model_name, version=version, non_conservative=True
+                    model=model_name, version=version, non_conservative=non_conservative
                 )
         else:
             calc = UPETCalculator(
-                model=model_name, version=version, non_conservative=True
+                model=model_name, version=version, non_conservative=non_conservative
             )
             atoms.calc = calc
             energy = atoms.get_potential_energy()

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -10,7 +10,7 @@ from upet.calculator import UPETCalculator
 
 @pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)
 def test_non_conservative(model_name):
-    non_conservative = True
+    non_conservative = "forces"
 
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -11,9 +11,10 @@ def test_non_conservative(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
-        bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
-        if "spice" not in model_name
-        else molecule("H2O")
+        molecule("H2O")
+        # models trained on molecular data only
+        if any(name in model_name for name in ("spice", "mols"))
+        else bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
     )
 
     model, size = model_name.rsplit("-", 1)

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from ase.build import bulk, molecule
 
@@ -12,7 +14,6 @@ def test_non_conservative(model_name):
         pytest.skip("Skipping XL models and L models due to large size.")
     atoms = (
         molecule("H2O")
-        # models trained on molecular data only
         if any(name in model_name for name in ("spice", "mols"))
         else bulk("C", cubic=True, a=5.43, crystalstructure="diamond")
     )
@@ -22,10 +23,12 @@ def test_non_conservative(model_name):
 
     for version in all_model_versions:
         if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
-            with pytest.raises(
-                NotImplementedError,
-                match="Non-conservative forces and stresses are not available",
-            ):
+            message = (
+                f"Non-conservative forces are not available for the model "
+                f"{model_name}, v{version}. Please run without "
+                "non_conservative=True, or choose another model."
+            )
+            with pytest.raises(NotImplementedError, match=re.escape(message)):
                 calc = UPETCalculator(
                     model=model_name, version=version, non_conservative=True
                 )

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -43,7 +43,7 @@ def test_calc_rot_averaging(model_name):
 
 @pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)
 def test_calc_rot_averaging_non_conservative(model_name):
-    non_conservative = True
+    non_conservative = "forces"
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     version = max(get_versions_for_model(*model_name.rsplit("-", 1)))

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 from ase.build import bulk
 
-from upet._version import UPET_AVAILABLE_MODELS
+from upet._models import upet_resolve_model
+from upet._version import UPET_AVAILABLE_MODELS, UPET_NO_NC_SUPPORT_MODELS
 from upet.calculator import UPETCalculator
 
 
@@ -42,7 +43,8 @@ def test_calc_rot_averaging(model_name):
 def test_calc_rot_averaging_non_conservative(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
-    if model_name in ["pet-spice-s", "pet-spice-l"]:
+    _, latest_version = upet_resolve_model(*model_name.rsplit("-", 1))
+    if f"{model_name}-v{latest_version}" in UPET_NO_NC_SUPPORT_MODELS:
         msg = "Non-conservative forces and stresses are not available"
         with pytest.raises(NotImplementedError, match=msg):
             _ = UPETCalculator(model=model_name, non_conservative=True)

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -43,14 +43,17 @@ def test_calc_rot_averaging(model_name):
 
 @pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)
 def test_calc_rot_averaging_non_conservative(model_name):
+    non_conservative = True
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     version = max(get_versions_for_model(*model_name.rsplit("-", 1)))
     if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
         message = (
-            f"Non-conservative forces are not available for the model "
-            f"{model_name}, v{version}. Please run without "
-            "non_conservative=True, or choose another model."
+            f"`non-conservative={non_conservative}` option is not available "
+            f"for the model {model_name}, v{version}, and a target variant "
+            f"`energy`. Please choose another `non-conservative` option, "
+            "use another target variant, switch to a conservative regime "
+            "or choose another model."
         )
         with pytest.raises(NotImplementedError, match=re.escape(message)):
             _ = UPETCalculator(model=model_name, non_conservative=True)

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -56,11 +56,11 @@ def test_calc_rot_averaging_non_conservative(model_name):
             "or choose another model."
         )
         with pytest.raises(NotImplementedError, match=re.escape(message)):
-            _ = UPETCalculator(model=model_name, non_conservative=True)
+            _ = UPETCalculator(model=model_name, non_conservative=non_conservative)
     else:
         atoms = bulk("Si", cubic=True, a=5.43, crystalstructure="diamond")
         atoms.rattle(0.05)
-        atoms.calc = UPETCalculator(model=model_name, non_conservative=True)
+        atoms.calc = UPETCalculator(model=model_name, non_conservative=non_conservative)
 
         target_energy = atoms.get_potential_energy()
         target_forces = atoms.get_forces()
@@ -68,7 +68,7 @@ def test_calc_rot_averaging_non_conservative(model_name):
 
         atoms.calc = UPETCalculator(
             model=model_name,
-            non_conservative=True,
+            non_conservative=non_conservative,
             rotational_average_order=3,
             rotational_average_batch_size=8,
         )

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -1,8 +1,10 @@
+import re
+
 import numpy as np
 import pytest
 from ase.build import bulk
 
-from upet._models import upet_resolve_model
+from upet._models import get_versions_for_model
 from upet._version import UPET_AVAILABLE_MODELS, UPET_NO_NC_SUPPORT_MODELS
 from upet.calculator import UPETCalculator
 
@@ -43,10 +45,14 @@ def test_calc_rot_averaging(model_name):
 def test_calc_rot_averaging_non_conservative(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
-    _, latest_version = upet_resolve_model(*model_name.rsplit("-", 1))
-    if f"{model_name}-v{latest_version}" in UPET_NO_NC_SUPPORT_MODELS:
-        msg = "Non-conservative forces and stresses are not available"
-        with pytest.raises(NotImplementedError, match=msg):
+    version = max(get_versions_for_model(*model_name.rsplit("-", 1)))
+    if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
+        message = (
+            f"Non-conservative forces are not available for the model "
+            f"{model_name}, v{version}. Please run without "
+            "non_conservative=True, or choose another model."
+        )
+        with pytest.raises(NotImplementedError, match=re.escape(message)):
             _ = UPETCalculator(model=model_name, non_conservative=True)
     else:
         atoms = bulk("Si", cubic=True, a=5.43, crystalstructure="diamond")

--- a/tests/upet/test_uncertainty_quantification.py
+++ b/tests/upet/test_uncertainty_quantification.py
@@ -42,6 +42,22 @@ def test_uncertainty_quantification(model_name):
             assert np.allclose(energy_ensemble, energy_ensemble_2, atol=1e-6)
 
 
+def test_uncertainty_with_rotational_averaging():
+    # uncertainty outputs are requested from the base model, so they are available
+    # but not themselves rotationally averaged
+    atoms = bulk("Si", cubic=True, a=5.43, crystalstructure="diamond")
+    calc = UPETCalculator(
+        model="pet-mad-s", version="1.5.0", rotational_average_order=3
+    )
+    plain_calc = UPETCalculator(model="pet-mad-s", version="1.5.0")
+
+    assert np.allclose(
+        calc.get_energy_uncertainty(atoms),
+        plain_calc.get_energy_uncertainty(atoms),
+        atol=1e-6,
+    )
+
+
 def test_error_model_not_evaluated():
     atoms = bulk("Si", cubic=True, a=5.43, crystalstructure="diamond")
     calc = UPETCalculator(


### PR DESCRIPTION
The `metatrain` pin no longer resolved against a released version. Bumping it to
v2026.4 pulls in metatomic-torch 0.1.17, which deprecates two `ModelOutput`
arguments we passed: `quantity` is dropped, and `per_atom` becomes `sample_kind`.
Our own `per_atom` arguments stay as they are.

It also fixes the uncertainty methods when rotational averaging is on. They were
called on the `SymmetrizedCalculator`, which does not have the attributes they
need, so they raised an `AttributeError` as soon as `rotational_average_order`
was set. They now go to the calculator it wraps, since uncertainties are not
rotationally averaged. Nothing tested the two together, hence the silence.
