### PR TITLE
Read the model information from the model

### DIFF
--- a/docs/src/models.rst
+++ b/docs/src/models.rst
@@ -193,9 +193,7 @@ All UPET checkpoints support conservative forces (the derivative of the
 predicted energy). Most also expose a direct, non-conservative force head
 that is 2–3× faster at inference; see :ref:`ase-non-conservative`. The
 following checkpoints are conservative-only and therefore do **not**
-support ``non_conservative=True``
-(:py:attr:`~upet.calculator.UPETCalculator.supports_non_conservative` tells
-them apart):
+support ``non_conservative=True``:
 
 - ``pet-mad-s`` v1.0.2
 - ``pet-spice-s`` v0.2.0

--- a/docs/src/models.rst
+++ b/docs/src/models.rst
@@ -182,7 +182,9 @@ and :py:meth:`~upet.calculator.UPETCalculator.get_energy_ensemble`
 - ``pet-mols-s`` v1.0.0
 - ``pet-mols-s`` v1.1.0
 
-Calling these methods on other checkpoints will raise an error.
+Calling these methods on other checkpoints will raise an error;
+:py:attr:`~upet.calculator.UPETCalculator.supports_uncertainty` tells whether
+the model at hand provides them.
 
 Non-conservative forces
 -----------------------
@@ -191,7 +193,9 @@ All UPET checkpoints support conservative forces (the derivative of the
 predicted energy). Most also expose a direct, non-conservative force head
 that is 2–3× faster at inference; see :ref:`ase-non-conservative`. The
 following checkpoints are conservative-only and therefore do **not**
-support ``non_conservative=True``:
+support ``non_conservative=True``
+(:py:attr:`~upet.calculator.UPETCalculator.supports_non_conservative` tells
+them apart):
 
 - ``pet-mad-s`` v1.0.2
 - ``pet-spice-s`` v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
 
 dependencies = [
     "metatrain>=2026.4, <2026.5",
-    "metatomic-ase>=0.1.3, <0.2",
+    "metatomic-ase>=0.1.2, <0.2",
     "nvalchemi-toolkit-ops",
     "warp-lang",
     "huggingface_hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 dependencies = [
     "metatrain>=2026.4, <2026.5",
     "metatomic-ase>=0.1.2, <0.2",
-    "nvalchemi-toolkit-ops>=0.3.0,<=0.4.0",
+    "nvalchemi-toolkit-ops>=0.3.0,<0.4.0",
     "warp-lang",
     "huggingface_hub",
     "hf_xet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 dependencies = [
     "metatrain>=2026.4, <2026.5",
     "metatomic-ase>=0.1.2, <0.2",
-    "nvalchemi-toolkit-ops",
+    "nvalchemi-toolkit-ops>=0.3.0,<=0.4.0",
     "warp-lang",
     "huggingface_hub",
     "hf_xet",

--- a/src/upet/_metadata.py
+++ b/src/upet/_metadata.py
@@ -1,3 +1,5 @@
+"""Metadata for the checkpoints that do not carry their own."""
+
 from typing import Optional
 
 from metatomic.torch import ModelMetadata
@@ -8,6 +10,12 @@ def get_upet_metadata(
     size: Optional[str] = None,
     version: Optional[str] = None,
 ) -> ModelMetadata:
+    """Describe a model that was published without any metadata of its own.
+
+    Newer checkpoints store their name, description, authors and references,
+    which is where the ones of a new model belong; this only covers the models
+    published before that.
+    """
     description = (
         r"A universal interatomic potential for advanced materials modeling "
         r"based on a Point-Edge Transformer (PET) architecture, and trained on "
@@ -22,49 +30,7 @@ def get_upet_metadata(
     }
 
     if model and size and version:
-        dataset = model.split("-")[1].upper()
-        description_text = description.format(dataset, size, version)
-        if "mols" in model.lower():
-            # PET-MOLS is not a universal potential, so it does not use the
-            # generic description above
-            description_text = (
-                r"A machine-learning interatomic potential to study organic "
-                r"molecular crystals, trained on periodic PBE0+MBD reference "
-                r"data, covering 12 elements and a broad range of organic "
-                r"motifs subsampled from the Cambridge Structural Database. "
-                r"Model size: {}. Model version: {}.".format(size, version)
-            )
-            # same order as the model paper (arXiv:2603.06236)
-            authors = [
-                "Matthias Kellner (matthias.kellner@epfl.ch)",
-                "Ruben Rodriguez-Madrid",
-                "Jacob B. Holmes",
-                "Victor Paul Principe",
-                "Seio Inoue",
-                "Lyndon Emsley",
-                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-            ]
-            references = {"model": ["https://arxiv.org/abs/2603.06236"]}
-        elif "omol" in model.lower():
-            description_text = description.format("OMol25", size, version)
-            # same order as the model paper (doi:10.1088/2632-2153/ae6417)
-            authors = [
-                "Filippo Bigi (filippo.bigi@epfl.ch)",
-                "Paolo Pegolo (paolo.pegolo@epfl.ch)",
-                "Arslan Mazitov (arslan.mazitov@epfl.ch)",
-                "Jonathan Schmidt",
-                "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-            ]
-            references = {
-                "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
-                # ``dataset`` is not an accepted key of the references, so the
-                # OMol25 dataset paper is listed together with the model one
-                "model": [
-                    "https://doi.org/10.1088/2632-2153/ae6417",
-                    "https://arxiv.org/abs/2505.08762",
-                ],
-            }
-        elif "mad" in model.lower():
+        if "mad" in model.lower():
             authors = [
                 "Arslan Mazitov (arslan.mazitov@epfl.ch)",
                 "Filippo Bigi",
@@ -85,7 +51,7 @@ def get_upet_metadata(
             ]
         metadata = ModelMetadata(
             name=f"{model.upper()}-{size.upper()} v{version}",
-            description=description_text,
+            description=description.format(model.split("-")[1].upper(), size, version),
             authors=authors,
             references=references,
         )

--- a/src/upet/_models.py
+++ b/src/upet/_models.py
@@ -158,6 +158,17 @@ def upet_resolve_model(
     return size, version
 
 
+def _model_holding_the_metadata(model: torch.nn.Module) -> torch.nn.Module:
+    """Give back the model whose metadata ends up in the exported model.
+
+    An uncertainty model has metadata of its own, but the one of the model it
+    wraps takes precedence when exporting, so that is the one to look at (and to
+    fill in, for a checkpoint that came without any).
+    """
+    wrapped = getattr(model, "model", None)
+    return model if wrapped is None else wrapped
+
+
 def _get_upet_exported_atomistic_model(
     model: Optional[str] = None,
     size: Optional[str] = None,
@@ -217,9 +228,13 @@ def _get_upet_exported_atomistic_model(
         )
         loaded_model = load_metatrain_model(path)
 
-    metadata = get_upet_metadata(model=model, size=size, version=str(version))
-    exported_model = loaded_model.export(metadata)
-    return exported_model
+    described_model = _model_holding_the_metadata(loaded_model)
+    if not described_model.metadata.name:
+        described_model.metadata = get_upet_metadata(
+            model=model, size=size, version=str(version)
+        )
+
+    return loaded_model.export()
 
 
 def get_upet(

--- a/src/upet/_version.py
+++ b/src/upet/_version.py
@@ -20,22 +20,6 @@ UPET_AVAILABLE_MODELS = [
     "pet-spice-l",
 ]
 
-UPET_NO_NC_SUPPORT_MODELS = [
-    "pet-mad-s-v1.0.2",
-    "pet-spice-s-v0.2.0",
-    "pet-spice-l-v0.2.0",
-    "pet-mols-s-v1.0.0",
-    "pet-mols-s-v1.1.0",
-]
-
-UPET_UQ_SUPPORTED_MODELS = [
-    "pet-mad-s-v1.0.2",
-    "pet-mad-xs-v1.5.0",
-    "pet-mad-s-v1.5.0",
-    "pet-mols-s-v1.0.0",
-    "pet-mols-s-v1.1.0",
-]
-
 DEPRECATED_MODELS: list[str] = []
 
 # PET-MAD DOS

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -20,7 +20,6 @@ from ._models import (
 from ._version import (
     PET_MAD_DOS_LATEST_STABLE_VERSION,
     UPET_AVAILABLE_MODELS,
-    UPET_UQ_SUPPORTED_MODELS,
 )
 from .utils import (
     dos_from_eigenvalues,
@@ -167,26 +166,29 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
                 checkpoint_path=checkpoint_path,
             )
 
+        model_outputs = loaded_model.capabilities().outputs
+        selected_variant = None if variants is None else variants.get("energy")
+        variant_postfix = f"/{selected_variant}" if selected_variant else ""
+        nc_forces_key = "non_conservative_force" + variant_postfix
+        nc_stress_key = "non_conservative_stress" + variant_postfix
+
+        self._available_nc_quantities = []
+        for quantity, key in zip(
+            ["forces", "stress"], [nc_forces_key, nc_stress_key], strict=True
+        ):
+            if key in model_outputs:
+                self._available_nc_quantities.append(quantity)
+
         if non_conservative:
-            model_outputs = loaded_model.capabilities().outputs
-            selected_variant = None if variants is None else variants.get("energy")
-            variant_postfix = f"/{selected_variant}" if selected_variant else ""
-            nc_forces_key = "non_conservative_force" + variant_postfix
-            nc_stress_key = "non_conservative_stress" + variant_postfix
+            if non_conservative is True:
+                requested_nc_quantities = {"forces", "stress"}
+            else:
+                requested_nc_quantities = {non_conservative}
 
-            missing_nc_forces = (
-                non_conservative in ("forces", True)
-                and nc_forces_key not in model_outputs
-            )
-            missing_nc_stress = (
-                non_conservative in ("stress", True)
-                and nc_stress_key not in model_outputs
-            )
-
-            if missing_nc_forces or missing_nc_stress:
+            if not requested_nc_quantities.issubset(self._available_nc_quantities):
                 raise NotImplementedError(
                     f"`non-conservative={non_conservative}` option is not available "
-                    f"for the model {model}, v{version}, and a target variant "
+                    f"for the model {model} v{version}, and a target variant "
                     f"`{selected_variant or 'energy'}`. Please choose another "
                     f"`non-conservative` option, use another target variant, "
                     "switch to a conservative regime or choose another model."
@@ -254,17 +256,22 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             return calc.base_calculator
         return calc
 
+    @property
+    def supports_uncertainty(self) -> bool:
+        """Whether the calculator supports uncertainty quantification."""
+        return self._base_calculator._calculate_uncertainty
+
     def _run_uq(
         self,
         atoms: Optional[Atoms] = None,
         per_atom: bool = False,
         key: str = "energy_uncertainty",
     ) -> np.ndarray:
-        if not self._base_calculator._calculate_uncertainty:
+        if not self.supports_uncertainty:
             raise NotImplementedError(
-                "Energy uncertainty and ensemble are not available for the selected "
-                "model. For uncertainty estimates, please use one of the following "
-                f"models: {UPET_UQ_SUPPORTED_MODELS}"
+                "Energy uncertainty and ensemble are not available for the "
+                "selected model. The documentation lists the models providing "
+                "uncertainty estimates."
             )
 
         if atoms is None:

--- a/src/upet/calculator.py
+++ b/src/upet/calculator.py
@@ -20,7 +20,6 @@ from ._models import (
 from ._version import (
     PET_MAD_DOS_LATEST_STABLE_VERSION,
     UPET_AVAILABLE_MODELS,
-    UPET_UQ_SUPPORTED_MODELS,
 )
 from .utils import (
     dos_from_eigenvalues,
@@ -164,13 +163,15 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
             )
 
         model_outputs = loaded_model.capabilities().outputs
+        selected_variant = None if variants is None else variants.get("energy")
+        variant_postfix = f"/{selected_variant}" if selected_variant else ""
+        nc_forces_key = "non_conservative_force" + variant_postfix
+        nc_stress_key = "non_conservative_stress" + variant_postfix
+        self._supports_non_conservative = nc_forces_key in model_outputs
+
         nc_regime: Union[bool, Literal["forces", "stress"]] = non_conservative
         if non_conservative:
-            selected_variant = None if variants is None else variants.get("energy")
-            variant_postfix = f"/{selected_variant}" if selected_variant else ""
-            nc_forces_key = "non_conservative_force" + variant_postfix
-            nc_stress_key = "non_conservative_stress" + variant_postfix
-            if nc_forces_key not in model_outputs:
+            if not self._supports_non_conservative:
                 raise NotImplementedError(
                     "Non-conservative forces are not available for the "
                     f"model {model}, v{version}. Please run without "
@@ -235,6 +236,24 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         self.results = self.calculator.results
 
     @property
+    def supports_non_conservative(self) -> bool:
+        """Whether the model predicts non-conservative forces.
+
+        These are only available for the models that were trained on them; the
+        other ones can only be run with ``non_conservative=False``.
+        """
+        return self._supports_non_conservative
+
+    @property
+    def supports_uncertainty(self) -> bool:
+        """Whether the model predicts an uncertainty on its energy.
+
+        This is what :py:meth:`get_energy_uncertainty` and
+        :py:meth:`get_energy_ensemble` need to be usable.
+        """
+        return self._base_calculator._calculate_uncertainty
+
+    @property
     def _base_calculator(self) -> MetatomicCalculator:
         """The underlying calculator, unwrapped from rotational averaging."""
         calc = self.calculator
@@ -248,11 +267,11 @@ class UPETCalculator(ase.calculators.calculator.Calculator):
         per_atom: bool = False,
         key: str = "energy_uncertainty",
     ) -> np.ndarray:
-        if not self._base_calculator._calculate_uncertainty:
+        if not self.supports_uncertainty:
             raise NotImplementedError(
-                "Energy uncertainty and ensemble are not available for the selected "
-                "model. For uncertainty estimates, please use one of the following "
-                f"models: {UPET_UQ_SUPPORTED_MODELS}"
+                "Energy uncertainty and ensemble are not available for the "
+                "selected model. The documentation lists the models providing "
+                "uncertainty estimates."
             )
 
         if atoms is None:

--- a/tests/upet/_utils.py
+++ b/tests/upet/_utils.py
@@ -1,0 +1,30 @@
+"""Expected model capabilities, asserted against what the library reports."""
+
+# Models whose checkpoints do not expose `non_conservative_*` outputs.
+UPET_NO_NC_SUPPORT_MODELS = frozenset(
+    {
+        "pet-mad-s-v1.0.2",
+        "pet-spice-s-v0.2.0",
+        "pet-spice-l-v0.2.0",
+        "pet-mols-s-v1.0.0",
+        "pet-mols-s-v1.1.0",
+    }
+)
+
+
+def supports_non_conservative(model_name, version) -> bool:
+    """Whether ``model_name`` at ``version`` is expected to provide NC outputs."""
+    return f"{model_name}-v{version}" not in UPET_NO_NC_SUPPORT_MODELS
+
+
+def non_conservative_error_message(
+    model_name, version, non_conservative, variant="energy"
+) -> str:
+    """The error `UPETCalculator` is expected to raise for an unsupported model."""
+    return (
+        f"`non-conservative={non_conservative}` option is not available "
+        f"for the model {model_name} v{version}, and a target variant "
+        f"`{variant}`. Please choose another `non-conservative` option, "
+        "use another target variant, switch to a conservative regime "
+        "or choose another model."
+    )

--- a/tests/upet/test_basic_usage.py
+++ b/tests/upet/test_basic_usage.py
@@ -4,6 +4,8 @@ import pytest
 from ase.build import bulk, molecule
 
 from upet._models import (
+    get_available_models,
+    get_sizes_for_model,
     get_upet,
     get_versions_for_model,
     list_upet,
@@ -56,6 +58,22 @@ def test_get_upet(model_name):
 
     for version in all_model_versions:
         get_upet(model=model, size=size, version=version)
+
+
+def test_available_models_are_published():
+    """Check that every model offered here can be downloaded.
+
+    Models published on the hub but missing from the list are not an error:
+    a model can be uploaded before it is offered here.
+    """
+    published = {
+        f"{model}-{size}"
+        for model in get_available_models()
+        for size in get_sizes_for_model(model)
+    }
+    missing = sorted(set(UPET_AVAILABLE_MODELS) - published)
+
+    assert missing == [], f"not published on the hub: {missing}"
 
 
 def test_list_models():

--- a/tests/upet/test_metadata.py
+++ b/tests/upet/test_metadata.py
@@ -1,4 +1,5 @@
 from upet._metadata import get_upet_metadata
+from upet._models import get_upet
 
 
 PET_REFERENCES = {
@@ -46,42 +47,16 @@ def test_metadata_mad():
     assert metadata.references == PET_REFERENCES
 
 
-def test_metadata_omol():
-    """Check the dataset name, which is not the one derived from the model name."""
-    metadata = get_upet_metadata("pet-omol", "s", "1.0.0")
-
-    assert metadata.name == "PET-OMOL-S v1.0.0"
-    assert metadata.description == (
-        "A universal interatomic potential for advanced materials modeling based "
-        "on a Point-Edge Transformer (PET) architecture, and trained on the "
-        "OMol25 dataset. Model size: s. Model version: 1.0.0."
-    )
-    assert metadata.authors == [
-        "Filippo Bigi (filippo.bigi@epfl.ch)",
-        "Paolo Pegolo (paolo.pegolo@epfl.ch)",
-        "Arslan Mazitov (arslan.mazitov@epfl.ch)",
-        "Jonathan Schmidt",
-        "Michele Ceriotti (michele.ceriotti@epfl.ch)",
-    ]
-    assert metadata.references == {
-        "architecture": ["https://doi.org/10.1088/2632-2153/ae6417"],
-        "model": [
-            "https://doi.org/10.1088/2632-2153/ae6417",
-            "https://arxiv.org/abs/2505.08762",
-        ],
-    }
-
-
-def test_metadata_mols():
-    """Check the description of the only model that is not a universal potential."""
-    metadata = get_upet_metadata("pet-mols", "s", "1.1.0")
+def test_metadata_from_checkpoint():
+    """Check that the metadata of a model that has some of its own is kept."""
+    metadata = get_upet(model="pet-mols", size="s", version="1.1.0").metadata()
 
     assert metadata.name == "PET-MOLS-S v1.1.0"
     assert metadata.description == (
         "A machine-learning interatomic potential to study organic molecular "
         "crystals, trained on periodic PBE0+MBD reference data, covering 12 "
         "elements and a broad range of organic motifs subsampled from the "
-        "Cambridge Structural Database. Model size: s. Model version: 1.1.0."
+        "Cambridge Structural Database. Model size: S. Model version: 1.1.0."
     )
     assert metadata.authors == [
         "Matthias Kellner (matthias.kellner@epfl.ch)",
@@ -92,4 +67,10 @@ def test_metadata_mols():
         "Lyndon Emsley",
         "Michele Ceriotti (michele.ceriotti@epfl.ch)",
     ]
-    assert metadata.references == {"model": ["https://arxiv.org/abs/2603.06236"]}
+
+
+def test_metadata_of_uncertainty_model():
+    """Check a model without metadata, wrapped in an uncertainty model."""
+    metadata = get_upet(model="pet-mad", size="xs", version="1.5.0").metadata()
+
+    assert metadata.name == "PET-MAD-XS v1.5.0"

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -4,8 +4,10 @@ import pytest
 from ase.build import bulk, molecule
 
 from upet._models import get_versions_for_model
-from upet._version import UPET_AVAILABLE_MODELS, UPET_NO_NC_SUPPORT_MODELS
+from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
+
+from _utils import non_conservative_error_message, supports_non_conservative
 
 
 @pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)
@@ -24,16 +26,12 @@ def test_non_conservative(model_name):
     all_model_versions = get_versions_for_model(model, size)
 
     for version in all_model_versions:
-        if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
-            message = (
-                f"`non-conservative={non_conservative}` option is not available "
-                f"for the model {model_name}, v{version}, and a target variant "
-                f"`energy`. Please choose another `non-conservative` option, "
-                "use another target variant, switch to a conservative regime "
-                "or choose another model."
+        if not supports_non_conservative(model_name, version):
+            message = non_conservative_error_message(
+                model_name, version, non_conservative
             )
             with pytest.raises(NotImplementedError, match=re.escape(message)):
-                calc = UPETCalculator(
+                UPETCalculator(
                     model=model_name, version=version, non_conservative=non_conservative
                 )
         else:

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -1,13 +1,12 @@
 import re
 
 import pytest
+from _utils import non_conservative_error_message, supports_non_conservative
 from ase.build import bulk, molecule
 
 from upet._models import get_versions_for_model
 from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
-
-from _utils import non_conservative_error_message, supports_non_conservative
 
 
 @pytest.mark.parametrize("model_name", UPET_AVAILABLE_MODELS)

--- a/tests/upet/test_non_conservative.py
+++ b/tests/upet/test_non_conservative.py
@@ -4,7 +4,7 @@ import pytest
 from ase.build import bulk, molecule
 
 from upet._models import get_versions_for_model
-from upet._version import UPET_AVAILABLE_MODELS, UPET_NO_NC_SUPPORT_MODELS
+from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
 
 
@@ -22,7 +22,9 @@ def test_non_conservative(model_name):
     all_model_versions = get_versions_for_model(model, size)
 
     for version in all_model_versions:
-        if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
+        if not UPETCalculator(
+            model=model_name, version=version
+        ).supports_non_conservative:
             message = (
                 f"Non-conservative forces are not available for the model "
                 f"{model_name}, v{version}. Please run without "

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -5,7 +5,7 @@ import pytest
 from ase.build import bulk
 
 from upet._models import get_versions_for_model
-from upet._version import UPET_AVAILABLE_MODELS, UPET_NO_NC_SUPPORT_MODELS
+from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
 
 
@@ -46,7 +46,7 @@ def test_calc_rot_averaging_non_conservative(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     version = max(get_versions_for_model(*model_name.rsplit("-", 1)))
-    if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
+    if not UPETCalculator(model=model_name).supports_non_conservative:
         message = (
             f"Non-conservative forces are not available for the model "
             f"{model_name}, v{version}. Please run without "

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -5,8 +5,10 @@ import pytest
 from ase.build import bulk
 
 from upet._models import get_versions_for_model
-from upet._version import UPET_AVAILABLE_MODELS, UPET_NO_NC_SUPPORT_MODELS
+from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
+
+from _utils import non_conservative_error_message, supports_non_conservative
 
 
 GRID_ORDERS = [3, 5]
@@ -47,14 +49,8 @@ def test_calc_rot_averaging_non_conservative(model_name):
     if "-xl" in model_name or "-l" in model_name:
         pytest.skip("Skipping XL models and L models due to large size.")
     version = max(get_versions_for_model(*model_name.rsplit("-", 1)))
-    if f"{model_name}-v{version}" in UPET_NO_NC_SUPPORT_MODELS:
-        message = (
-            f"`non-conservative={non_conservative}` option is not available "
-            f"for the model {model_name}, v{version}, and a target variant "
-            f"`energy`. Please choose another `non-conservative` option, "
-            "use another target variant, switch to a conservative regime "
-            "or choose another model."
-        )
+    if not supports_non_conservative(model_name, version):
+        message = non_conservative_error_message(model_name, version, non_conservative)
         with pytest.raises(NotImplementedError, match=re.escape(message)):
             _ = UPETCalculator(model=model_name, non_conservative=non_conservative)
     else:

--- a/tests/upet/test_rot_averaging.py
+++ b/tests/upet/test_rot_averaging.py
@@ -2,13 +2,12 @@ import re
 
 import numpy as np
 import pytest
+from _utils import non_conservative_error_message, supports_non_conservative
 from ase.build import bulk
 
 from upet._models import get_versions_for_model
 from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
-
-from _utils import non_conservative_error_message, supports_non_conservative
 
 
 GRID_ORDERS = [3, 5]

--- a/tests/upet/test_uncertainty_quantification.py
+++ b/tests/upet/test_uncertainty_quantification.py
@@ -1,9 +1,11 @@
+import re
+
 import numpy as np
 import pytest
 from ase.build import bulk
 
 from upet._models import get_versions_for_model
-from upet._version import UPET_AVAILABLE_MODELS, UPET_UQ_SUPPORTED_MODELS
+from upet._version import UPET_AVAILABLE_MODELS
 from upet.calculator import UPETCalculator
 
 
@@ -21,9 +23,13 @@ def test_uncertainty_quantification(model_name):
             model=model_name,
             version=version,
         )
-        if f"{model_name}-v{version}" not in UPET_UQ_SUPPORTED_MODELS:
-            msg = "Energy uncertainty and ensemble are not available "
-            with pytest.raises(NotImplementedError, match=msg):
+        if not calc.supports_uncertainty:
+            message = (
+                "Energy uncertainty and ensemble are not available for the "
+                "selected model. The documentation lists the models providing "
+                "uncertainty estimates."
+            )
+            with pytest.raises(NotImplementedError, match=re.escape(message)):
                 calc.get_energy_uncertainty(atoms)
         else:
             energy_uncertainty = calc.get_energy_uncertainty(atoms)


### PR DESCRIPTION
Adding PET-OMol and PET-MOLS in #161 meant editing a metadata function and two
lists of model versions by hand. The models already carry all of it:

- the metadata now comes from the checkpoint. This also fixes PET-MAD v1.5.0,
  which was exported without a name or a description: the metadata we passed was
  overwritten by the empty metadata of the model inside the uncertainty model.
- `supports_non_conservative` and `supports_uncertainty` read the capabilities,
  replacing the two lists that said the same thing by hand.
- `UPET_AVAILABLE_MODELS` stays, since it is the list of models we choose to
  offer, but a test now checks that they all exist on the hub.
